### PR TITLE
refactor(expotv): simplify Metro config by using Expo-provided monorepo config

### DIFF
--- a/packages/expotv/metro.config.js
+++ b/packages/expotv/metro.config.js
@@ -1,24 +1,8 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
-const { getMetroTools, getMonorepoRoot } = require("react-native-monorepo-tools");
-const path = require('path');
-
-const projectRoot = __dirname;
-const monorepoRoot = getMonorepoRoot();
-const metroTools = getMetroTools();
 
 /** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(projectRoot); // eslint-disable-line no-undef
-
-config.resolver.nodeModulesPaths = [
-  path.resolve(projectRoot, 'node_modules'),
-  path.resolve(monorepoRoot, 'node_modules'),
-];
-
-// Configure for monorepo - watch the shared workspace
-config.watchFolders = metroTools.watchFolders;
-config.resolver.extraNodeModules = metroTools.extraNodeModules;
-config.resolver.blockList = metroTools.blockList;
+const config = getDefaultConfig(__dirname);
 
 // When enabled, the optional code below will allow Metro to resolve
 // and bundle source files with TV-specific extensions

--- a/packages/expotv/package.json
+++ b/packages/expotv/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@react-native-tvos/config-tv": "^0.1.4",
     "@types/react": "~19.1.10",
-    "react-native-monorepo-tools": "^1.2.1",
     "typescript": "~5.9.2"
   },
   "expo": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,7 +3009,6 @@ __metadata:
     react-dom: "npm:19.1.0"
     react-native: "npm:react-native-tvos@0.81-stable"
     react-native-gesture-handler: "npm:~2.28.0"
-    react-native-monorepo-tools: "npm:^1.2.1"
     react-native-reanimated: "npm:~4.1.1"
     react-native-safe-area-context: "npm:~5.6.0"
     react-native-screens: "npm:~4.16.0"


### PR DESCRIPTION
Hi! My name is Cedric, and I work on devtooling @expo. We saw this repository, and I thought I'd propose some simplifications on Expo's side. Feel free to ignore it, or use it 😄 

**Changes:** simplify ExpoTV Metro config with default Expo monorepo support
1. Dropped manual `config.watchFolders` override
2. Dropped manual `config.nodeModulesPath` override
3. Dropped manual `config.extraNodeModules` override
4. Dropped manual `config.blockList` override
5. Dropped `react-native-monorepo-tools` as its unused after the changes

> Note, both `packages/vega` and `packages/shared` are untouched.

Expo [already comes with monorepo support out-of-the-box](https://docs.expo.dev/guides/monorepos/). It actually has a few additional things that you wouldn't be able to get with `react-native-monorepo-tools`, the biggest one being pnpm/bun with isolated dependencies support. Not only did we get this to work properly, we also switched [our own monorepo to pnpm](https://github.com/expo/expo/blob/main/pnpm-lock.yaml) to improve maintenance overhead, DX in general with faster installs, and enforce workspace dependencies better. Since pnpm uses `pnpm-workspace.yaml`, [I don't think you can get that to work with `react-native-monorepo-tools`](https://github.com/mmazzarolo/react-native-monorepo-tools/blob/e68f0fb9ce448adb32e83a4229a4b1424ec0d73f/src/get-workspaces.js#L14).

We also have a few ideas we want to test for SDK 56 which could make `config.watchFolders` obsolete while also reducing the startup time from Metro through crawling. But, more on that later 😄

I also see that `nodeModulesPath` was configured, but I don't think this actually does anything. [Metro documents it as following](https://metrobundler.dev/docs/configuration):
> A list of paths to check for modules after looking through all node_modules directories. This is useful if third-party dependencies are installed in a different location outside of the direct path of source files. For more information, see [Module Resolution](https://metrobundler.dev/docs/resolution).

Which means that it's mostly a fallback option, and with workspaces being set to pretty much always resolve, this fallback is never really hit. The same actually applies to `extraNodeModules` as well, if you look at Metro's own resolution documentation: https://metrobundler.dev/docs/resolution/

And lastly, `blockList` is [kind of _really_ slow](https://x.com/Baconbrix/status/1768752862446620736). Unless you have a good reason to set it, which cannot be done through custom resolutions, I would avoid this at all costs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
