### PR TITLE
refactor(expotv): enable Expo autolinking module resolution

### DIFF
--- a/packages/expotv/app.json
+++ b/packages/expotv/app.json
@@ -48,6 +48,7 @@
       "output": "static"
     },
     "experiments": {
+      "autolinkingModuleResolution": true,
       "typedRoutes": true
     },
     "newArchEnabled": true,


### PR DESCRIPTION
Changes:
- Enabled `experiments.autolinkingModuleResolution: true` in `packages/expotv`

As a follow-up of #8, I also spotted that Vega is running React Native 0.72 - while ExpoTV is running React Native 0.81. In these cases, where multiple React Native versions live inside a single monorepo, I think it's a good idea to turn on our special resolver to align what was autolinked with what should be resolved. It makes working in a monorepo easier and more stable when using multiple versions of React Native.

> This is an opt-in for SDK 54, and is enabled by default in SDK 55.

See: https://docs.expo.dev/versions/latest/config/app/\#autolinkingmoduleresolution
See: https://docs.expo.dev/modules/autolinking/\#dependency-resolution-and-conflicts
See: https://docs.expo.dev/guides/monorepos/\#deduplicating-auto-linked-native-modules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
