### PR TITLE
Upgrade to SDK 0.24.9914

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 .yarn/unplugged
 .yarn/build-state.yml
 .yarn/install-state.gz
+.npmrc
 
 # Vega build files
 packages/vega/buildinfo.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
- @amazon-devices:registry=https://k-artifactory-external.labcollab.net/artifactory/api/npm/vegasdk-npm-rn83-alpha_prod/
- always-auth=true
- strict-ssl=true

--- a/packages/vega/manifest.toml
+++ b/packages/vega/manifest.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 id = "com.amazondeveloper.hellosharedworkspace"
 
 [os.version]
+min = "1.2"
 target = "1.2"
 
 [components]

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -33,7 +33,7 @@
     "react-native-safe-area-context": "^5.5.2"
   },
   "devDependencies": {
-    "@amazon-devices/kepler-cli-platform": "0.22.13",
+    "@amazon-devices/kepler-cli-platform": "0.22.13-rn-83",
     "@amazon-devices/keplerscript-commonmodules": "^1.0.0",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",

--- a/vega-sdk-requirements.json
+++ b/vega-sdk-requirements.json
@@ -1,3 +1,3 @@
 {
-  "vegaSdkVersion": "0.24.9525"
+  "vegaSdkVersion": "0.24.9914"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,9 +12,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@amazon-devices/kepler-cli-platform@npm:0.22.13":
-  version: 0.22.13
-  resolution: "@amazon-devices/kepler-cli-platform@npm:0.22.13"
+"@amazon-devices/kepler-cli-platform@npm:0.22.13-rn-83":
+  version: 0.22.13-rn-83
+  resolution: "@amazon-devices/kepler-cli-platform@npm:0.22.13-rn-83"
   dependencies:
     "@amazon-devices/kepler-compatibility-metro-config": "npm:^0"
     "@amazon-devices/kepler-module-manifest-builder": "npm:^0.1.0"
@@ -35,7 +35,7 @@ __metadata:
   dependenciesMeta:
     "@amazon-devices/keplerscript-commonmodules":
       optional: true
-  checksum: 10c0/aaccc4d03bdf1526600fdf861eee95b8355c5aa06c48fe17dc679cb7ecd36fd6a1ef221a579fad49c0d8f2f021ade56876119a476409b4e30f24db744b4a2818
+  checksum: 10c0/48b422381153d2ddd4cc87c3500289d7129710667fd768c3213e501bf49ad5058f8c52c914a8ee08ddaa3c6936eae3d09bcd9f01b4eb701dae0ab60a5410b28a
   languageName: node
   linkType: hard
 
@@ -2968,7 +2968,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@multitv/vega@workspace:packages/vega"
   dependencies:
-    "@amazon-devices/kepler-cli-platform": "npm:0.22.13"
+    "@amazon-devices/kepler-cli-platform": "npm:0.22.13-rn-83"
     "@amazon-devices/kepler-module-resolver-preset": "npm:^0.1.15"
     "@amazon-devices/keplerscript-commonmodules": "npm:^1.0.0"
     "@amazon-devices/lottie-react-native": "npm:~3.0.9000000000+6.0.0-rc.1"


### PR DESCRIPTION
# Upgrade to Vega SDK 0.24.9914

**Fix:** Upgrade Vega app to  Vega SDK 0.24.9914
This PR addresses issue #36.

SDK version 0.24.9525 was required but not available, and `@amazon-devices/kepler-cli-platform@0.22.13` was also missing.

After copying some config / dependencies from antoher working sample project, I was able to run the application successfully with latest Vega SDK 0.24.9914.

## Changes
- Bump `vegaSdkVersion` to `0.24.9914` in `vega-sdk-requirements.json`
- Pin `@amazon-devices/kepler-cli-platform` to `0.22.13-rn-83`
- Set `os.version.min = "1.2"` in `manifest.toml` alongside existing `target`
- Update `yarn.lock` accordingly

## Testing

The Vega app runs successfully with latest SDK 0.24.9914 VVD and confirms the expected behavior.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.